### PR TITLE
Fix "Add task"

### DIFF
--- a/src/kanban/actions.cljc
+++ b/src/kanban/actions.cljc
@@ -154,8 +154,9 @@
         ctx {:store store
              :event (:replicant/dom-event event-opts)
              :handle-actions (partial handle-actions store event-opts placeholders)}]
-    (doseq [action (->> (expand-actions state actions action-data)
-                        (mapcat :expanded)
-                        (expand-placeholders event-opts placeholders))]
+    (doseq [action (->> action-data
+                        (expand-placeholders event-opts placeholders)
+                        (expand-actions state actions )
+                        (mapcat :expanded))]
       (let [f (get-in actions [(first action) :execute])]
         (f ctx action)))))


### PR DESCRIPTION
event/form-data is now resolved before expanding

This was throwing an error in the background and add task didn't work because of it.